### PR TITLE
Change wording on "Didn't like CS" stat, as that sounds sort of negative and isn't super clear

### DIFF
--- a/src/components/Index/Stats.js
+++ b/src/components/Index/Stats.js
@@ -44,7 +44,7 @@ export default function Stats(props) {
           <StatBox
             num={Math.round(100 * (rollupStats.statLowInterestCount / rollupStats.statStudentCount))}
             unit="%"
-            label="Didn't Like CS"
+            label="Didn't Like CS Coming In"
             d={{ base: 'none', md: 'block' }}
           />
           <StatBox


### PR DESCRIPTION
I don't think my change is much better, since now it's a lot longer than the other things, but I think this needs to be changed. The way it was before, it almost sounds like they didn't like it afterwards. After reading the other stats, it's clear what it means, but there's probably a better way to say it.