### PR TITLE
added socials

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-countup": "^4.3.3",
     "react-dom": "^17.0.2",
     "react-globe": "^5.0.2",
+    "react-icons": "^4.8.0",
     "react-intersection-observer": "^8.29.1",
     "react-linkedin-insight": "^0.1.3",
     "react-page-visibility": "^6.2.0",

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -55,9 +55,11 @@ export default function Page ({ children, title, darkHeader, slug }) {
           {children}
         </Main>
         <Footer repository="www-corp" branch="master" mt={32}>
-          <CustomLinks>
-            <Link href="/help" d="block">FAQs &amp; Help</Link>
-            <Link href="/docs" d="block">Legal Documents</Link>
+          <CustomLinks style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <Link href="https://twitter.com/codeday" target="_blank"><FaTwitter size={28}/></Link>
+            <Link href="https://discord.gg/codeday" target="_blank"><FaDiscord size={28}/></Link>
+            <Link href="https://linkedin.com/company/codeday-org" d="block"><FaLinkedin size={28}/></Link>
+            <Link href="https://instagram.com/codeday_org" d="block"><FaInstagram size={28}/></Link>
           </CustomLinks>
         </Footer>
       </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,6 +3831,11 @@ react-globe@^5.0.2:
     three.interaction "^0.2.3"
     tippy.js "^6.2.6"
 
+react-icons@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.8.0.tgz#621e900caa23b912f737e41be57f27f6b2bff445"
+  integrity sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==
+
 react-intersection-observer@^8.29.1:
   version "8.29.1"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.29.1.tgz#8c6f494ca81b39aee9f509f12d29443fc66a2256"


### PR DESCRIPTION
I've just added four social links to the homepage! However, since there are different links for Clear and Corp, I don't think it's the best idea to add them to the topo for now. I removed the `https://www.codeday.org/docs` link from the footer's More section. Should I add it to the footer's Resources section in topo?