### PR TITLE
Require linkedin for industry + display API errors to user

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -24,7 +24,7 @@ export default function App ({ Component, pageProps }) {
   return (
     <>
       <Script dangerouslySetInnerHTML={{ __html: renderSnippet() }} />
-      <ThemeProvider withChat brandColor="red" analyticsId="AHHYLKBK" useSystemColorMode>
+      <ThemeProvider withChat brandColor="red" analyticsId="AHHYLKBK" useSystemColorMode cookies={pageProps.cookies}>
         <Provider value={pageProps?.query || {}}>
           <Component {...pageProps} />
         </Provider>


### PR DESCRIPTION
Per request of @CLiu13, this PR makes linkedin a required field for industry applicants, which will hopefully reduce the number of non-industry applicants, and make the non-industry applicants who apply under industry easier to detect.

This also fixes some broken error handling code which will display to users a special page when the call to /api/applyAsVolunteer failed, with a CTA to email us. Previously, users would have seen an error toast on submit in this case, but only for client side errors, and `fetch` does not throw an error when the request is not OK.

An applyAsVolunteer API error will also intentionally not redirect an application with the `after` URL parameter set, as this would result in the user being unaware their application was not processed server-side.

 
